### PR TITLE
refactor!: use `[u8; 16]` instead of `u128`

### DIFF
--- a/src/anonymize.rs
+++ b/src/anonymize.rs
@@ -1,5 +1,20 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+/// Merges 2 arrays of same length into 1 using a given closure.
+///
+/// Basically `Iterator::zip(a, b).map(f)` if `a` and `b` were iterators.
+#[allow(dead_code)]
+fn zip_with<F, const N: usize>(a: &[u8; N], b: &[u8; N], f: F) -> [u8; N]
+where
+    F: Fn(u8, u8) -> u8,
+{
+    std::array::from_fn(|i| unsafe {
+        let a = a.get_unchecked(i);
+        let b = b.get_unchecked(i);
+        f(*a, *b)
+    })
+}
+
 /// Defines a common interface for encrypting a 128-bit data.
 ///
 /// Although AES-128 is commonly used by CryptoPAn implementations, any 128-bit [block cipher]

--- a/src/backends/openssl.rs
+++ b/src/backends/openssl.rs
@@ -77,10 +77,11 @@ mod tests {
         let encrypter = Aes128Enc::new(ENC_KEY)?;
         let pancake = Anonymizer::with_encrypter(encrypter, PAD_KEY);
 
-        for (addr, expected) in cases {
-            let anonymized = pancake.anonymize_str(addr);
-            let expected: IpAddr = expected.parse().unwrap();
-            assert_eq!(anonymized, expected);
+        for (address, anonymized) in cases {
+            let original: IpAddr = address.parse().unwrap();
+            let anonymized: IpAddr = anonymized.parse().unwrap();
+
+            assert_eq!(pancake.anonymize_ip(original), anonymized);
         }
 
         Ok(())


### PR DESCRIPTION
The use of `u128` in the current implementation is a source of confusion and inefficiency.

- Frequent conversion between array and integer
- Have to be mindful about the endianness every time
- Use of a fixed sized integer makes it harder to make the algorithm generic over block size

This PR refactors the fields and methods to use `[u8; 16]` on every occasion.
The `anonymize*()` APIs are adjusted and reworked accordingly.

### Before

```rust
pub struct Anonymizer<E: Encrypter> {
    encrypter: E,
    padding: u128,
}

impl<E: Encrypter> Anonymizer<E> {
    pub fn anonymize(&self, addr: IpAddr) -> IpAddr;
    fn anonymize_bin(&self, addr: u128, version: u8) -> u128;
}
```

### After

```rust
pub struct Anonymizer<E: Encrypter> {
    encrypter: E,
    padding: [u8; 16]
}

impl<E: Encrypter> Anonymizer<E> {
    pub fn anonymize(&self, bytes: &[u8; 16], n_bits: usize) -> [u8; 16];
    pub fn anonymize_ip(&self, addr: IpAddr) -> IpAddr;
    pub fn anonymize_ipv4(&self, addr: Ipv4Addr) -> Ipv4Addr;
    pub fn anonymize_ipv6(&self, addr: Ipv6Addr) -> Ipv6Addr;
}
```
